### PR TITLE
Add test for cli.py

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+from click.testing import CliRunner
+
+from hibpcli.cli import main
+
+
+def test_main_returns_leaked_entry():
+    runner = CliRunner()
+    result = runner.invoke(main, input="\n".join(["tests/test.kdbx", "test"]))
+    expected_output = """Please enter the path to the database: tests/test.kdbx
+Please enter the master password for the database: 
+The passwords of following entries are leaked:
+[b'Entry: "test_title (test_user)"']
+"""
+    assert result.output == expected_output


### PR DESCRIPTION
Adding a basic test was very easy, thanks to the excellent
documentation of the click maintainers:
https://click.palletsprojects.com/en/7.x/testing/#input-streams

This is a first attempt to increase test coverage, cf #6.

new file:   tests/test_cli.py