### PR TITLE
Make sure input is a correct path

### DIFF
--- a/hibpcli/cli.py
+++ b/hibpcli/cli.py
@@ -5,7 +5,7 @@ from hibpcli.keepass import check_passwords_from_db
 
 @click.command()
 def main():
-    path = click.prompt("Please enter the path to the database")
+    path = click.prompt("Please enter the path to the database", type=click.Path(exists=True))
     master_password = click.prompt("Please enter the master password for the database", hide_input=True)
     # needs error handling
     rv = check_passwords_from_db(path=path, master_password=master_password)


### PR DESCRIPTION
Until right now there was no input check for "path".

Once again, the click framework makes it very easy to improve the
situation.

Now, the input gets checked via adding a type=click.Path arguemnt
when calling the prompt method.

Closes #8.

modified:   hibpcli/cli.py