### PR TITLE
Add docstring for main function

### DIFF
--- a/hibpcli/cli.py
+++ b/hibpcli/cli.py
@@ -5,6 +5,7 @@ from hibpcli.keepass import check_passwords_from_db
 
 @click.command()
 def main():
+    """Command line interface to the haveibeenpwned.com API."""
     path = click.prompt("Please enter the path to the database", type=click.Path(exists=True))
     master_password = click.prompt("Please enter the master password for the database", hide_input=True)
     # needs error handling


### PR DESCRIPTION
Click automatically shows the docstring of the main function when
using the --help option.

modified:   hibpcli/cli.py