### PR TITLE
Move keepass check into subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Very alpha.
 ## usage
 
 ```
-$ python -m hibpcli.cli
+$ python -m hibpcli.cli keepass
 
 Please enter the path to the database: tests/test.kdbx
 Please enter the master password for the database:

--- a/hibpcli/cli.py
+++ b/hibpcli/cli.py
@@ -3,9 +3,14 @@ import click
 from hibpcli.keepass import check_passwords_from_db
 
 
-@click.command()
+@click.group()
 def main():
     """Command line interface to the haveibeenpwned.com API."""
+    pass
+
+@click.command()
+def keepass():
+    """Check all passwords stored in the keepass database."""
     path = click.prompt("Please enter the path to the database", type=click.Path(exists=True))
     master_password = click.prompt("Please enter the master password for the database", hide_input=True)
     # needs error handling
@@ -15,6 +20,9 @@ def main():
         click.echo(rv)
     else:
         click.echo("Hooray, everything is safe!")
+
+
+main.add_command(keepass)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,9 @@ from click.testing import CliRunner
 from hibpcli.cli import main
 
 
-def test_main_returns_leaked_entry():
+def test_keepass_subcommand_returns_leaked_entry():
     runner = CliRunner()
-    result = runner.invoke(main, input="\n".join(["tests/test.kdbx", "test"]))
+    result = runner.invoke(main, ["keepass"], input="\n".join(["tests/test.kdbx", "test"]))
     expected_output = """Please enter the path to the database: tests/test.kdbx
 Please enter the master password for the database: 
 The passwords of following entries are leaked:


### PR DESCRIPTION
In order to prepare for the new interface #17, the keepass check
was moved into its own subcommand.

modified:   README.md
modified:   hibpcli/cli.py
modified:   tests/test_cli.py