### PR TITLE
Make sure module can be used as main programm

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pytest
 ## run tests with coverage
 
 ```
-pytest --cov=hibpcli --cov-report term-missing
+pytest --cov=hibpcli --cov=tests --cov-report term-missing
 ```
 
 ## thank you

--- a/tests/test_main_programm.py
+++ b/tests/test_main_programm.py
@@ -1,0 +1,10 @@
+import os
+
+
+def test_usage_of_module_as_main_programm():
+    """Make sure module can be executed.
+
+    More info about this interesting way of testing:
+    https://mail.python.org/pipermail/tutor/2016-February/108119.html
+    """
+    assert os.system("python -m hibpcli.cli") == 0


### PR DESCRIPTION
Python has this interesting idiom "if __name__ == __main__", which
determines what to do when a module is imported or directly called.

It is odd to test, though, as - when importing the module into
your test suite - you cannot reach the other branch.

There are different workarounds available. Thanks to Steve for his
answer about how to test this idiom:
https://mail.python.org/pipermail/tutor/2016-February/108119.html

With this test, the coverage now has reached 100%!!

Still, tests have to be improved, as some call the live API and
other issues.

modified:   README.md
new file:   tests/test_main_programm.py