### PR TITLE
Add LeaksStore to cache all leaked passwords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,9 @@ added
 - add the `bandit` security checker
 - add support for Python 3.9
 - add type annotations
-- improve message when there are no known leaks for a password(@eumiro)
+- improve message when there are no known leaks for a password (@eumiro)
 - provide user friendly error message when given password is wrong
+- provide caching for password lookups (@eumiro)
 
 0.4.1 (30.09.2020)
 ------------------

--- a/src/hibpcli/cli.py
+++ b/src/hibpcli/cli.py
@@ -3,7 +3,7 @@ from typing import Optional
 import click
 from hibpcli.exceptions import ApiError, KeepassError
 from hibpcli.keepass import check_passwords_from_db
-from hibpcli.password import LeaksStore
+from hibpcli.leaks import LeaksStore
 
 
 @click.group()

--- a/src/hibpcli/cli.py
+++ b/src/hibpcli/cli.py
@@ -3,7 +3,7 @@ from typing import Optional
 import click
 from hibpcli.exceptions import ApiError, KeepassError
 from hibpcli.keepass import check_passwords_from_db
-from hibpcli.password import Password
+from hibpcli.password import LeaksStore
 
 
 @click.group()
@@ -43,9 +43,9 @@ def check_password(password: Optional[str]) -> None:
         password = click.prompt(
             "Please enter a password which should be checked", hide_input=True
         )
-    p = Password(password)
+    leaksstore = LeaksStore()
     try:
-        is_leaked = p.is_leaked()
+        is_leaked = password in leaksstore
     except ApiError as e:
         click.echo(str(e))
     else:

--- a/src/hibpcli/keepass.py
+++ b/src/hibpcli/keepass.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from hibpcli.password import LeaksStore
 from hibpcli.exceptions import KeepassError
+from hibpcli.leaks import LeaksStore
 from pykeepass import PyKeePass  # type: ignore
 from pykeepass.exceptions import CredentialsError
 
@@ -14,8 +14,4 @@ def check_passwords_from_db(path: str, master_password: str) -> List[str]:
         raise KeepassError
     else:
         leaksstore = LeaksStore()
-        return [
-            entry
-            for entry in kp.entries
-            if entry.password in leaksstore
-        ]
+        return [entry for entry in kp.entries if entry.password in leaksstore]

--- a/src/hibpcli/keepass.py
+++ b/src/hibpcli/keepass.py
@@ -1,7 +1,7 @@
 from typing import List
 
+from hibpcli.password import LeaksStore
 from hibpcli.exceptions import KeepassError
-from hibpcli.password import Password
 from pykeepass import PyKeePass  # type: ignore
 from pykeepass.exceptions import CredentialsError
 
@@ -13,8 +13,9 @@ def check_passwords_from_db(path: str, master_password: str) -> List[str]:
     except CredentialsError:
         raise KeepassError
     else:
+        leaksstore = LeaksStore()
         return [
             entry
             for entry in kp.entries
-            if Password(password=entry.password).is_leaked()
+            if entry.password in leaksstore
         ]

--- a/src/hibpcli/leaks.py
+++ b/src/hibpcli/leaks.py
@@ -19,9 +19,7 @@ class LeaksStore:
     def _load_page(self, hash_head: str) -> dict:
         """Load a list of leaked passwords for a given hash_head and return a set."""
         try:
-            result = httpx.get(
-                f"https://api.pwnedpasswords.com/range/{hash_head}"
-            ).text
+            result = httpx.get(f"https://api.pwnedpasswords.com/range/{hash_head}").text
         except socket.gaierror:
             raise ApiError("Error: Could not get a result from the API.")
         else:

--- a/tests/test_cli_for_check_keepass.py
+++ b/tests/test_cli_for_check_keepass.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from hibpcli.cli import main
 from hibpcli.exceptions import ApiError
-from hibpcli.password import LeaksStore
+from hibpcli.leaks import LeaksStore
 
 
 @patch("hibpcli.cli.check_passwords_from_db")

--- a/tests/test_cli_for_check_keepass.py
+++ b/tests/test_cli_for_check_keepass.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from hibpcli.cli import main
 from hibpcli.exceptions import ApiError
-from hibpcli.password import Password
+from hibpcli.password import LeaksStore
 
 
 @patch("hibpcli.cli.check_passwords_from_db")
@@ -71,7 +71,7 @@ def test_keepass_subcommand_with_path_and_password_options(mock_check):
     assert result.output == expected_output
 
 
-@patch.object(Password, "is_leaked")
+@patch.object(LeaksStore, "__contains__")
 def test_keepass_subcommand_error_handling(mock_password):
     mock_password.side_effect = ApiError("Error")
     runner = CliRunner()

--- a/tests/test_cli_for_check_password.py
+++ b/tests/test_cli_for_check_password.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from hibpcli.cli import main
 from hibpcli.exceptions import ApiError
-from hibpcli.password import LeaksStore
+from hibpcli.leaks import LeaksStore
 
 
 @patch.object(LeaksStore, "__contains__", return_value=True)

--- a/tests/test_cli_for_check_password.py
+++ b/tests/test_cli_for_check_password.py
@@ -4,10 +4,10 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from hibpcli.cli import main
 from hibpcli.exceptions import ApiError
-from hibpcli.password import Password
+from hibpcli.password import LeaksStore
 
 
-@patch.object(Password, "is_leaked", return_value=True)
+@patch.object(LeaksStore, "__contains__", return_value=True)
 def test_password_subcommand_for_leaked_password(mock_password):
     runner = CliRunner()
     result = runner.invoke(main, ["check-password", "--password", "test"])
@@ -15,7 +15,7 @@ def test_password_subcommand_for_leaked_password(mock_password):
     assert result.output == expected_output
 
 
-@patch.object(Password, "is_leaked", return_value=False)
+@patch.object(LeaksStore, "__contains__", return_value=False)
 def test_password_subcommand_for_safe_password(mock_password):
     runner = CliRunner()
     result = runner.invoke(main, ["check-password", "--password", "test"])
@@ -23,7 +23,7 @@ def test_password_subcommand_for_safe_password(mock_password):
     assert result.output == expected_output
 
 
-@patch.object(Password, "is_leaked", return_value=False)
+@patch.object(LeaksStore, "__contains__", return_value=False)
 def test_password_subcommand_with_prompt(mock_password):
     runner = CliRunner()
     result = runner.invoke(main, ["check-password"], input="test")
@@ -34,7 +34,7 @@ def test_password_subcommand_with_prompt(mock_password):
     assert result.output == textwrap.dedent(expected_output)
 
 
-@patch.object(Password, "is_leaked", side_effect=ApiError("Error"))
+@patch.object(LeaksStore, "__contains__", side_effect=ApiError("Error"))
 def test_password_subcommand_error_handling(mock_password):
     runner = CliRunner()
     result = runner.invoke(main, ["check-password", "--password", "test"])

--- a/tests/test_keepass.py
+++ b/tests/test_keepass.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from hibpcli.keepass import check_passwords_from_db
 
 
-@patch("hibpcli.keepass.Password.is_leaked")
+@patch("hibpcli.keepass.LeaksStore.__contains__")
 def test_check_passwords_from_db(mock_is_leaked):
     path = "tests/test.kdbx"
     password = "test"  # nosec

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from hibpcli.exceptions import ApiError
-from hibpcli.password import LeaksStore
+from hibpcli.leaks import LeaksStore
 
 # this is just a small part of a real response
 RESPONSE_TEXT = textwrap.dedent(
@@ -22,7 +22,7 @@ def test_password_signature():
         None in leaksstore  # type: ignore
 
 
-@patch("hibpcli.password.httpx.get")
+@patch("hibpcli.leaks.httpx.get")
 def test_is_leaked_password(mock_get):
     mock_get.return_value.text = RESPONSE_TEXT
     leaksstore = LeaksStore()
@@ -30,7 +30,7 @@ def test_is_leaked_password(mock_get):
     mock_get.assert_called_with("https://api.pwnedpasswords.com/range/A94A8")
 
 
-@patch("hibpcli.password.httpx.get")
+@patch("hibpcli.leaks.httpx.get")
 def test_is_leaked_raises_api_error(mock_get):
     mock_get.side_effect = socket.gaierror
     leaksstore = LeaksStore()

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from hibpcli.exceptions import ApiError
-from hibpcli.password import Password
+from hibpcli.password import LeaksStore
 
 # this is just a small part of a real response
 RESPONSE_TEXT = textwrap.dedent(
@@ -17,21 +17,22 @@ RESPONSE_TEXT = textwrap.dedent(
 
 
 def test_password_signature():
+    leaksstore = LeaksStore()
     with pytest.raises(TypeError):
-        Password()  # type: ignore
+        None in leaksstore  # type: ignore
 
 
 @patch("hibpcli.password.httpx.get")
 def test_is_leaked_password(mock_get):
     mock_get.return_value.text = RESPONSE_TEXT
-    p = Password("test")
-    assert p.is_leaked() is True
+    leaksstore = LeaksStore()
+    assert "test" in leaksstore
     mock_get.assert_called_with("https://api.pwnedpasswords.com/range/A94A8")
 
 
 @patch("hibpcli.password.httpx.get")
 def test_is_leaked_raises_api_error(mock_get):
     mock_get.side_effect = socket.gaierror
-    p = Password("test")
+    leaksstore = LeaksStore()
     with pytest.raises(ApiError):
-        p.is_leaked()
+        "test" in leaksstore


### PR DESCRIPTION
This replaces the single-use Password object with a container remembering all downloaded pages of leaked passwords.