### PR TITLE
Write safer negative report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ added
 - add the `bandit` security checker
 - add support for Python 3.9
 - add type annotations
+- tell the truth about safe password (@eumiro)
 
 0.4.1 (30.09.2020)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ added
 - add the `bandit` security checker
 - add support for Python 3.9
 - add type annotations
-- tell the truth about safe password (@eumiro)
+- improve message when there are no known leaks for a password(@eumiro)
 
 0.4.1 (30.09.2020)
 ------------------

--- a/src/hibpcli/cli.py
+++ b/src/hibpcli/cli.py
@@ -30,7 +30,7 @@ def check_keepass(path: str, password: Optional[str]) -> None:
             click.echo("The passwords of following entries are leaked:")
             click.echo(rv)
         else:
-            click.echo("Hooray, everything is safe!")
+            click.echo("Your passwords have not been reported leaked until now.")
 
 
 @click.command()
@@ -50,7 +50,7 @@ def check_password(password: Optional[str]) -> None:
         if is_leaked:
             click.echo("Please change your password!")
         else:
-            click.echo("Your password is safe!")
+            click.echo("Your password has not been reported leaked until now.")
 
 
 main.add_command(check_keepass)

--- a/tests/test_cli_for_check_keepass.py
+++ b/tests/test_cli_for_check_keepass.py
@@ -34,7 +34,7 @@ def test_keepass_subcommand_returns_all_ok(mock_check):
     expected_output = textwrap.dedent(
         """\
         Please enter the master password for the database: 
-        Hooray, everything is safe!
+        Your passwords have not been reported leaked until now.
     """  # noqa: W291
     )
     assert result.output == expected_output

--- a/tests/test_cli_for_check_password.py
+++ b/tests/test_cli_for_check_password.py
@@ -19,7 +19,7 @@ def test_password_subcommand_for_leaked_password(mock_password):
 def test_password_subcommand_for_safe_password(mock_password):
     runner = CliRunner()
     result = runner.invoke(main, ["check-password", "--password", "test"])
-    expected_output = "Your password is safe!\n"
+    expected_output = "Your password has not been reported leaked until now.\n"
     assert result.output == expected_output
 
 
@@ -29,7 +29,7 @@ def test_password_subcommand_with_prompt(mock_password):
     result = runner.invoke(main, ["check-password"], input="test")
     expected_output = """\
         Please enter a password which should be checked: 
-        Your password is safe!
+        Your password has not been reported leaked until now.
     """  # noqa: W291
     assert result.output == textwrap.dedent(expected_output)
 


### PR DESCRIPTION
Tell the user their password has not been reported leaked and not their password is safe.

Fixes #58 